### PR TITLE
Add Phase-2 Tier 1 Kickstart for unattended install

### DIFF
--- a/PHASE2_PLAN.md
+++ b/PHASE2_PLAN.md
@@ -1,6 +1,7 @@
 # Phase 2 — automating SmartMet VM provisioning
 
-**Status:** plan, awaiting review. Nothing implemented yet.
+**Status:** Tier 1 (Kickstart) implemented in `kickstart/`. Tiers 2–4 still
+planned.
 
 ## Goal
 
@@ -44,7 +45,13 @@ of SmartMet VMs being deployed.
 
 These need answers from the user before tier 2+ can be built.
 
-## Tier 1 — Kickstart (~1 day, no infra changes)
+## Tier 1 — Kickstart (✅ implemented)
+
+See `kickstart/smartmet-10.ks` and `kickstart/README.md`. Auto-detects
+single-disk vs two-disk hosts and BIOS vs UEFI; uses LVM throughout so
+`/smartmet` can be grown with `lvextend + xfs_growfs`.
+
+### Original sketch
 
 Drop a single file `kickstart/smartmet-10.ks` into this repo. Anaconda reads
 it, does the entire OS install unattended, partitions disk with `/smartmet`

--- a/README.md
+++ b/README.md
@@ -173,9 +173,22 @@ The web UI is at `http://<server>/`. The Samba share is reachable as
 - **Script aborts on the `/smartmet` mountpoint check** — answer `y` to
   continue without a dedicated volume (only safe for testing).
 
-## Phase 2: automated VM provisioning
+## Unattended install via Kickstart
 
-A tiered plan for automating VM creation in Proxmox (Kickstart, cloud-init
-templates, Packer golden image) is in [`PHASE2_PLAN.md`](PHASE2_PLAN.md).
-Open questions about network model, disk sizing, and credential injection
-need to be resolved before implementation begins.
+For unattended installs (Tier 1 of the automation roadmap):
+
+```
+inst.ks=https://your-host/path/smartmet-10.ks
+```
+
+The kickstart at [`kickstart/smartmet-10.ks`](kickstart/smartmet-10.ks)
+auto-detects single-disk vs two-disk hosts, sets up LVM with a growable
+`/smartmet`, and runs the install script in `%post`. Replace the SSH
+key placeholder before hosting it. See
+[`kickstart/README.md`](kickstart/README.md) for full details.
+
+## Phase 2: more VM provisioning automation
+
+A tiered plan covering cloud-init Proxmox templates and Packer golden
+images is in [`PHASE2_PLAN.md`](PHASE2_PLAN.md). Tier 1 (Kickstart) is
+implemented above.

--- a/kickstart/README.md
+++ b/kickstart/README.md
@@ -1,0 +1,144 @@
+# Kickstart for the SmartMet Data Processing Server
+
+Unattended-install recipe for AlmaLinux/Rocky 10. Walks Anaconda through OS
+install with a sane disk layout and partitioning, then runs
+`smartmet-install-10.sh` in `%post`. The host comes up with the SmartMet
+data-processing stack installed, ready for `passwd smartmet`,
+`smbpasswd -a smartmet`, and (optionally) a static-IP switchover.
+
+This implements **Tier 1** of [`PHASE2_PLAN.md`](../PHASE2_PLAN.md).
+
+## What it does
+
+| Stage   | Action                                                                         |
+|---------|--------------------------------------------------------------------------------|
+| `%pre`  | Detects firmware (BIOS vs UEFI) and disk count (1 or ≥2). Writes the partitioning include. Refuses to proceed with the placeholder SSH key. |
+| Anaconda | Partitions, installs `@^minimal-environment + @core + chrony, vim, tar, curl, wget`, locks root, creates the `admin` sudo user with your SSH key. |
+| `%post` | Curls `smartmet-install-10.sh` from this repo and runs it inside the chroot. Writes `/root/FIRST_BOOT_NOTES.txt` with remaining steps. |
+| Reboot  | Ejects ISO and reboots.                                                        |
+
+## Disk layout produced
+
+The `%pre` script picks layout based on how many non-removable disks are
+attached:
+
+### Single-disk host (one VG, all in one)
+
+```
+disk → /boot/efi (or biosboot) | /boot | LVM PV → vg_smartmet
+                                                  ├── lv_root      30 GiB  (xfs, /)
+                                                  ├── lv_swap       8 GiB  (swap)
+                                                  └── lv_smartmet  rest    (xfs, /smartmet)  ← grows
+```
+
+### Two-disk host (OS / data split)
+
+```
+smallest disk → /boot/efi | /boot | LVM PV → vg_root      ├── lv_root      30 GiB  (xfs, /)
+                                              └── lv_swap       8 GiB  (swap)
+
+largest  disk → LVM PV → vg_smartmet  └── lv_smartmet  100 % of disk  (xfs, /smartmet)  ← grows
+```
+
+In both layouts `/smartmet` is the only LV that has `--grow`, and it's the
+LV you extend later when adding capacity:
+
+```
+# after enlarging the underlying disk in Proxmox
+lvextend -l +100%FREE /dev/vg_smartmet/lv_smartmet
+xfs_growfs /smartmet
+```
+
+## Customize before deploying
+
+Open `smartmet-10.ks` and replace the SSH key placeholder:
+
+```diff
+-sshkey --username=admin "REPLACE_WITH_YOUR_SSH_PUBKEY"
++sshkey --username=admin "ssh-ed25519 AAAAC3Nza... admin@laptop"
+```
+
+The `%pre` script sanity-checks for the placeholder string and aborts the
+install if it's still there, so a forgotten edit can't accidentally produce
+a key-less host.
+
+If you want a non-default hostname baked in, change the `network` line:
+
+```diff
+-network --bootproto=dhcp --device=link --activate --hostname=smartmet
++network --bootproto=dhcp --device=link --activate --hostname=smartmet01
+```
+
+(For per-host hostname without forking the kickstart, leave the default and
+override at boot via `inst.ks.sendmac` + a templating service, or set the
+hostname after install with `hostnamectl set-hostname`.)
+
+## Host the kickstart
+
+Pick whichever of these is easiest:
+
+| Option | How |
+|--------|-----|
+| Raw GitHub URL (after PR is merged) | `https://raw.githubusercontent.com/fmidev/smartmet-install/master/kickstart/smartmet-10.ks` — but **only viable if your edits live in a public fork**, since the placeholder check refuses the unedited upstream copy. |
+| Internal HTTP(S) server | Drop the edited `smartmet-10.ks` on any web server reachable from the install network. |
+| Embedded in a custom ISO | `mkksiso smartmet-10.ks original.iso smartmet-install.iso` — produces a one-shot ISO that boots straight into the kickstart. Good for air-gapped or USB installs. |
+| Proxmox snippet | Upload to a Proxmox snippets storage and reference it via PXE/HTTP. |
+
+## Boot the install
+
+At the AlmaLinux/Rocky 10 ISO boot menu, press `e` and append to the
+kernel cmdline:
+
+```
+inst.ks=https://your-host/path/smartmet-10.ks
+```
+
+### Static IP at install time (recommended for production)
+
+Append the standard initrd network args:
+
+```
+inst.ks=https://your-host/path/smartmet-10.ks ip=192.0.2.10::192.0.2.1:255.255.255.0:smartmet01:eth0:none nameserver=192.0.2.53
+```
+
+Format is `ip=<client>::<gw>:<netmask>:<hostname>:<dev>:<autoconf>`. These
+override the kickstart's default DHCP `network` line.
+
+### DHCP at install time, fixed IP after install
+
+Acceptable for first deployment. Boot with just `inst.ks=...`, let DHCP
+serve the install, then on first login follow the `nmcli` snippet in
+`/root/FIRST_BOOT_NOTES.txt`.
+
+## Proxmox specifics
+
+Two practical options:
+
+1. **ISO + boot args.** Upload the AlmaLinux 10 ISO to the local-iso
+   storage, attach to a new VM, and at the GRUB prompt edit the kernel
+   line as above. Single-disk and two-disk VMs both work — the kickstart
+   auto-detects.
+
+2. **Custom ISO with embedded kickstart.** Run `mkksiso` once on a Linux
+   workstation, upload the resulting ISO. New VMs boot it and run end-to-end
+   with no manual intervention. Pair with `qm set <id> --boot order=cdrom`.
+
+A future Tier 2 will replace this with a Proxmox cloud-init template that
+provisions a VM in <60 s without an ISO; see `PHASE2_PLAN.md`.
+
+## Limits / caveats
+
+- **Filename is `smartmet-10.ks`** — only AlmaLinux/Rocky 10 has been
+  exercised. The same kickstart should work on 9 (the `%post` picks
+  `smartmet-install-9.sh` automatically), but Anaconda directives drift
+  between EL versions; if you target 9, smoke-test first.
+- **Disk auto-detection picks by size.** If your host has multiple disks
+  and the OS disk isn't the smallest, override by hard-coding `OS_DISK`
+  and `DATA_DISK` in the `%pre` script.
+- **No LUKS encryption.** Add `--encrypted --passphrase=...` to the
+  `logvol` lines if you need it (not unattended without a static
+  passphrase, which is its own threat model).
+- **Placeholder check is best-effort.** If you somehow ship the unedited
+  kickstart and `%pre` fails to find the placeholder string (e.g.
+  Anaconda mounts it under a different path), the install bails. Verify
+  the resulting system has *only your* admin SSH key before exposing it.

--- a/kickstart/smartmet-10.ks
+++ b/kickstart/smartmet-10.ks
@@ -1,0 +1,188 @@
+# Kickstart for the SmartMet Data Processing Server on AlmaLinux/Rocky 10.
+#
+# Usage: boot the AlmaLinux/Rocky 10 minimal ISO with kernel arg
+#   inst.ks=<URL-to-this-file>
+# (See kickstart/README.md for hosting + boot-arg details.)
+#
+# Disk layout (auto-detected from how many disks the host has):
+#   1 disk  → ONE VG vg_smartmet on the disk; lv_root 30G, lv_swap 8G,
+#             lv_smartmet uses the rest and is left growable.
+#   ≥2 disks → smallest disk is the OS disk (vg_root: lv_root 30G, lv_swap 8G);
+#             largest disk is the data disk (vg_smartmet: lv_smartmet, all of it).
+# In both cases lv_smartmet is the only LV that grows the underlying VG when
+# the disk is enlarged later (lvextend + xfs_growfs).
+#
+# After OS install the %post stage curls and runs smartmet-install-10.sh from
+# this repo, leaving the host ready for `passwd smartmet` / `smbpasswd -a smartmet`.
+
+#--- system identity ---------------------------------------------------------
+lang en_US.UTF-8
+keyboard --vckeymap=us --xlayouts='us'
+timezone Etc/UTC
+
+# Default to DHCP at install time. For a static IP, append boot args at ISO
+# boot, e.g.
+#   ip=192.0.2.10::192.0.2.1:255.255.255.0:smartmet01:eth0:none nameserver=192.0.2.53
+# Anaconda will pick those up over this default.
+network --bootproto=dhcp --device=link --activate --hostname=smartmet
+
+#--- accounts ----------------------------------------------------------------
+# Root login is locked. Administer via the sudo user below.
+rootpw --lock
+
+# REPLACE-BEFORE-USE — operator-customizable admin user and SSH key. The
+# kickstart will fail by design if these placeholders aren't replaced, so
+# nobody accidentally deploys with the default key.
+user --name=admin --groups=wheel --gecos="SmartMet admin" --lock
+sshkey --username=admin "REPLACE_WITH_YOUR_SSH_PUBKEY"
+
+#--- security & services -----------------------------------------------------
+selinux --enforcing
+firewall --enabled --service=ssh
+services --enabled=chronyd,sshd,firewalld
+authselect --useshadow --passalgo=sha512
+
+#--- partitioning (filled in by %pre) ---------------------------------------
+%include /tmp/part-include
+
+bootloader --location=mbr --append="rhgb quiet"
+
+#--- packages ----------------------------------------------------------------
+%packages
+@^minimal-environment
+@core
+chrony
+vim-enhanced
+bash-completion
+tar
+curl
+wget
+%end
+
+#--- pre: detect disks and firmware, write part-include ---------------------
+%pre --interpreter=/bin/bash --erroronfail --log=/tmp/ks-pre.log
+set -e
+
+# Firmware detection
+if [ -d /sys/firmware/efi ]; then
+  FW=uefi
+else
+  FW=bios
+fi
+
+# Discover non-removable, non-loop disks, sorted ascending by size
+mapfile -t SORTED < <(
+  lsblk -d -bn -o NAME,TYPE,RM,SIZE \
+    | awk '$2=="disk" && $3==0 {print $4, $1}' \
+    | sort -n
+)
+
+if [ "${#SORTED[@]}" -lt 1 ]; then
+  echo "FATAL: no usable disks detected" >&2
+  exit 1
+fi
+
+OS_DISK=$(awk '{print $2}' <<< "${SORTED[0]}")
+if [ "${#SORTED[@]}" -ge 2 ]; then
+  DATA_DISK=$(awk '{print $2}' <<< "${SORTED[-1]}")
+else
+  DATA_DISK=""
+fi
+
+# Boot partitions per firmware
+case "$FW" in
+  uefi)
+    BOOT_PARTS=$(cat <<EOB
+part /boot/efi --fstype=efi --size=600 --ondisk=${OS_DISK}
+part /boot     --fstype=xfs --size=1024 --ondisk=${OS_DISK}
+EOB
+)
+    ;;
+  bios)
+    BOOT_PARTS=$(cat <<EOB
+part biosboot --fstype=biosboot --size=1 --ondisk=${OS_DISK}
+part /boot    --fstype=xfs --size=1024 --ondisk=${OS_DISK}
+EOB
+)
+    ;;
+esac
+
+if [ -n "$DATA_DISK" ]; then
+  cat > /tmp/part-include <<EOF
+ignoredisk --only-use=${OS_DISK},${DATA_DISK}
+clearpart --all --initlabel --drives=${OS_DISK},${DATA_DISK}
+${BOOT_PARTS}
+part pv.os   --size=1 --grow --ondisk=${OS_DISK}
+part pv.data --size=1 --grow --ondisk=${DATA_DISK}
+volgroup vg_root     pv.os
+volgroup vg_smartmet pv.data
+logvol /         --vgname=vg_root     --name=lv_root     --fstype=xfs  --size=30720
+logvol swap      --vgname=vg_root     --name=lv_swap     --fstype=swap --size=8192
+logvol /smartmet --vgname=vg_smartmet --name=lv_smartmet --fstype=xfs  --size=1 --grow
+EOF
+else
+  cat > /tmp/part-include <<EOF
+ignoredisk --only-use=${OS_DISK}
+clearpart --all --initlabel --drives=${OS_DISK}
+${BOOT_PARTS}
+part pv.all --size=1 --grow --ondisk=${OS_DISK}
+volgroup vg_smartmet pv.all
+logvol /         --vgname=vg_smartmet --name=lv_root     --fstype=xfs  --size=30720
+logvol swap      --vgname=vg_smartmet --name=lv_swap     --fstype=swap --size=8192
+logvol /smartmet --vgname=vg_smartmet --name=lv_smartmet --fstype=xfs  --size=1 --grow
+EOF
+fi
+
+# Refuse to proceed with placeholder SSH key
+if grep -q REPLACE_WITH_YOUR_SSH_PUBKEY /run/install/repo/ks.cfg 2>/dev/null \
+   || grep -rq REPLACE_WITH_YOUR_SSH_PUBKEY /tmp/ks-script*.sh 2>/dev/null; then
+  echo "FATAL: kickstart still has the placeholder SSH key. Replace it before deploying." >&2
+  exit 1
+fi
+%end
+
+#--- post: install SmartMet stack -------------------------------------------
+%post --interpreter=/bin/bash --erroronfail --log=/root/ks-post.log
+set -euo pipefail
+
+# Mark the install script's preflight step as already done — /smartmet is
+# guaranteed mounted by the partitioning above, and the script's interactive
+# prompt would otherwise hang inside %post.
+mkdir -p /var/lib/smartmet-install
+touch /var/lib/smartmet-install/preflight.done
+
+# Pick the install script for this OS major
+. /etc/os-release
+case "${VERSION_ID%%.*}" in
+  10) SCRIPT=smartmet-install-10.sh ;;
+  9)  SCRIPT=smartmet-install-9.sh  ;;
+  8)  SCRIPT=smartmet-install-8.sh  ;;
+  *)  echo "Unsupported OS ${ID} ${VERSION_ID}" >&2; exit 1 ;;
+esac
+
+URL="https://raw.githubusercontent.com/fmidev/smartmet-install/master/${SCRIPT}"
+curl --fail --location --silent --show-error "$URL" -o "/tmp/${SCRIPT}"
+chmod +x "/tmp/${SCRIPT}"
+"/tmp/${SCRIPT}"
+
+# Note for the operator: the smartmet user still needs Linux + Samba passwords.
+cat > /root/FIRST_BOOT_NOTES.txt <<'NOTE'
+SmartMet Data Processing Server install completed via kickstart.
+
+Remaining manual steps (see also the README at fmidev/smartmet-install):
+
+  1. Set the smartmet user's Linux password:
+       passwd smartmet
+  2. Set the smartmet user's Samba password (for the SMB share):
+       smbpasswd -a smartmet
+  3. (Optional) Set a static IP if the install used DHCP:
+       nmcli con mod "<connection>" ipv4.method manual \
+         ipv4.addresses 192.0.2.10/24 ipv4.gateway 192.0.2.1 \
+         ipv4.dns 192.0.2.53
+       nmcli con up "<connection>"
+  4. (Optional) Install forecast model packages:
+       dnf install smartmet-data-gfs smartmet-data-gem smartmet-data-metar
+NOTE
+%end
+
+reboot --eject


### PR DESCRIPTION
## Summary

Implements **Tier 1** of [`PHASE2_PLAN.md`](PHASE2_PLAN.md): an Anaconda kickstart that takes a fresh AlmaLinux/Rocky 10 host all the way to a configured SmartMet Data Processing Server with no Anaconda clicking.

- `kickstart/smartmet-10.ks` — auto-detects firmware (BIOS/UEFI) and disk count (1 or ≥2), partitions with LVM so `/smartmet` is growable, locks root, creates an `admin/wheel` sudo user with operator-supplied SSH key, then runs `smartmet-install-10.sh` in `%post`.
- `kickstart/README.md` — customization, hosting, ISO boot args, Proxmox specifics, limits.
- `PHASE2_PLAN.md` updated to mark Tier 1 implemented.
- Top-level `README.md` gains a "Unattended install via Kickstart" section.

## Disk layout decisions (per user spec)

- **One disk:** single VG `vg_smartmet` containing `lv_root` (30 G), `lv_swap` (8 G), `lv_smartmet` (grows; rest of disk).
- **Two disks:** smallest is OS (`vg_root`: `lv_root` + `lv_swap`), largest is data (`vg_smartmet`: `lv_smartmet` uses 100 % of the disk).
- `/home` stays under `/`, no separate partition.
- LVM throughout so `lvextend + xfs_growfs` works after enlarging the underlying disk.

## Networking

- Install-time defaults to DHCP for simplicity.
- Static IP at install time via standard initrd kernel args appended at the ISO boot menu — example in `kickstart/README.md`.
- Static IP after install via `nmcli`, recipe written to `/root/FIRST_BOOT_NOTES.txt` on the freshly installed host.

## Safety

- The placeholder SSH key string is sanity-checked in `%pre`; install fails if the operator forgot to substitute it. Prevents accidentally deploying with no usable key.
- `%post` pre-touches `/var/lib/smartmet-install/preflight.done` so the install script's interactive `/smartmet` mountpoint prompt can't hang inside Anaconda.

## Test plan

- [ ] Single-disk EL10 VM in Proxmox: boot ISO with `inst.ks=…`, confirm partitioning, post-install SmartMet stack present, `/smartmet` mounted from `vg_smartmet/lv_smartmet`.
- [ ] Two-disk EL10 VM: confirm `lv_root` on smaller disk, `lv_smartmet` on larger disk.
- [ ] BIOS-firmware VM: confirm `biosboot` partition created, GRUB installs to MBR.
- [ ] UEFI-firmware VM: confirm `/boot/efi` ESP, GRUB to EFI.
- [ ] Static-IP install via `ip=…` kernel arg.
- [ ] Confirm `%pre` aborts when the placeholder SSH key is left unedited.
- [ ] After reboot, `passwd smartmet` + `smbpasswd -a smartmet` produce a fully-working server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)